### PR TITLE
Hotfix#120. Handle non-countable result in can_i_see_teacherrequestlink

### DIFF
--- a/classes/persistents/certifygen_context.php
+++ b/classes/persistents/certifygen_context.php
@@ -149,7 +149,7 @@ class certifygen_context extends persistent {
      */
     public static function can_i_see_teacherrequestlink(int $userid): bool {
         $result = get_user_capability_course('mod/certifygen:addinstance', $userid);
-        $numresult = count($result);
+        $numresult = (is_countable ($result)) ? count($result) : 0;
         if ($numresult > 0) {
             return true;
         }

--- a/classes/persistents/certifygen_context.php
+++ b/classes/persistents/certifygen_context.php
@@ -149,8 +149,7 @@ class certifygen_context extends persistent {
      */
     public static function can_i_see_teacherrequestlink(int $userid): bool {
         $result = get_user_capability_course('mod/certifygen:addinstance', $userid);
-        $numresult = (is_countable ($result)) ? count($result) : 0;
-        if ($numresult > 0) {
+        if ($result && count($result) > 0) {
             return true;
         }
         return false;


### PR DESCRIPTION
Resolved problem reported in https://github.com/UNIMOODLE/moodle-mod_certifygen/issues/120